### PR TITLE
Dev win

### DIFF
--- a/WinAutomation/Installation/WinServer-Core/Convert-CoreEdition.txt
+++ b/WinAutomation/Installation/WinServer-Core/Convert-CoreEdition.txt
@@ -1,0 +1,24 @@
+ @"
+>> # Convert Windows Server Evaluation to Standard Edition
+>> `$edition = "ServerTurbineCor"
+>> `$productKey = "H7XNC-JYM86-7B27X-8MJ9W-TKFX9" # Replace with a valid key
+>>
+>> Write-Host "Checking Current Edition..."
+>> `$currentEdition = (DISM /Online /Get-CurrentEdition | Select-String "Current Edition").Matches.Groups[0].Value.Trim()
+>> Write-Host "Current Edition: `$currentEdition"
+>>
+>> Write-Host "Checking Available Target Editions..."
+>> `$targetEditions = (DISM /Online /Get-TargetEditions | Select-String "Target Edition" | ForEach-Object { `$_.Line.Trim() })
+>> Write-Host "Available Target Editions: `$targetEditions"
+>>
+>> if (`$targetEditions -match `$edition) {
+>>     Write-Host "Upgrading to `$edition..."
+>>     DISM /Online /Set-Edition:`$edition /ProductKey:`$productKey /AcceptEula
+>>     Write-Host "Upgrade completed. Rebooting now..."
+>>     shutdown /r /t 10
+>> } else {
+>>     Write-Host "Error: Cannot upgrade to `$edition. Check available editions."
+>> }
+>>
+>> #
+>> "@ | Invoke-Expression

--- a/WinAutomation/Manage/Update-Powershell.txt
+++ b/WinAutomation/Manage/Update-Powershell.txt
@@ -1,0 +1,46 @@
+# If you'd like to update Powershell remotely with ssh for example
+# just copy and paste the code below straight into your terminal session
+# it will start update to the latest Powershell version and creates a schedule that will start in a minute
+# you won't be able to close your ssh session just exit from pwsh(Powershell) session and Powershell will be updated
+
+@"
+`$ErrorActionPreference = 'Stop'
+
+Write-Host 'Checking current PowerShell version...' -ForegroundColor Cyan
+`$currentVersion = `$PSVersionTable.PSVersion
+Write-Host "Current version: `$currentVersion"
+
+Write-Host 'Fetching latest release from GitHub...' -ForegroundColor Cyan
+`$release = Invoke-RestMethod -Uri 'https://api.github.com/repos/PowerShell/PowerShell/releases/latest' -UseBasicParsing
+`$latestVersion = `$release.tag_name.TrimStart('v')
+Write-Host "Latest version available: `$latestVersion"
+
+if ([version]`$latestVersion -le `$currentVersion) {
+    Write-Host 'You are already on the latest version!' -ForegroundColor Green
+    return
+}
+
+`$msiAsset = `$release.assets | Where-Object { `$_.name -match 'win-x64.msi$' }
+if (-not `$msiAsset) {
+    Write-Error 'Could not find MSI installer in latest release.'
+    return
+}
+
+`$msiUrl = `$msiAsset.browser_download_url
+`$msiFile = "`$env:TEMP\PowerShell-`$latestVersion-win-x64.msi"
+
+Write-Host 'Downloading MSI installer...' -ForegroundColor Cyan
+Invoke-WebRequest -Uri `$msiUrl -OutFile `$msiFile
+
+Write-Host 'Scheduling update task...' -ForegroundColor Cyan
+`$cmd = "msiexec.exe /i `$msiFile /quiet /norestart"
+`$taskName = 'UpdatePowerShell'
+
+`$Action = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument "/c `$cmd"
+`$Trigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddMinutes(1))
+`$Principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -RunLevel Highest
+Register-ScheduledTask -TaskName `$taskName -Action `$Action -Trigger `$Trigger -Principal `$Principal
+
+Write-Host 'Update scheduled. Please disconnect SSH session NOW!' -ForegroundColor Yellow
+Write-Host 'The update will run in about 1 minute.' -ForegroundColor Yellow
+"@ | Invoke-Expression


### PR DESCRIPTION
Scripts to covert Windows Server Core from Evaluation to Standard edition with clipboard script that ready to copy > paste = run
And another one to update Powershell to the latest version in the same way